### PR TITLE
Print model config and prompt once from shell script

### DIFF
--- a/cli/run_evaluation_tasks.sh
+++ b/cli/run_evaluation_tasks.sh
@@ -7,6 +7,7 @@ TASKS=(
     # These should be the task IDs from the evaluation set
 )
 MODEL_CONFIG="gpt-5-mini-2025-08-07-low"  # Or your preferred model config
+PROMPT_NAME="agent_coding_prompt"  # Prompt template to use
 DATA_DIR="data/arc-agi/data/evaluation"
 OUTPUT_DIR="results/evaluation"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
@@ -15,6 +16,9 @@ LOG_FILE="logs/evaluation_run_${TIMESTAMP}.log"
 # Create output and logs directories
 mkdir -p "$OUTPUT_DIR"
 mkdir -p "logs"
+
+# Print chosen model and prompt once
+echo "Using model config: $MODEL_CONFIG | Prompt: $PROMPT_NAME" | tee -a "$LOG_FILE"
 
 # Initialize results file
 echo "Task ID,Score,Cost,Attempts,Output Tokens,Duration" > "${OUTPUT_DIR}/results_summary.csv"
@@ -35,6 +39,7 @@ run_task() {
     python main.py \
         --task_id "$task_id" \
         --config "$MODEL_CONFIG" \
+        --prompt_name "$PROMPT_NAME" \
         --data_dir "$DATA_DIR" \
         --save_submission_dir "${task_dir}" \
         --print_submission \

--- a/main.py
+++ b/main.py
@@ -279,7 +279,6 @@ class ARCTester:
 
         # Use the config name as the test_id
         test_id = self.config
-        logger.info(f"{task_id} | {self.config} | {self.prompt_name} |")        
 
         # Logic for overwrite. If save_submission_dir is provided, check if the submission already exists
         if self.save_submission_dir:


### PR DESCRIPTION
## Summary
- Remove repetitive logging of model config and prompt from `main.py`
- Add `PROMPT_NAME` to evaluation script and print model/prompt once
- Pass prompt name to `main.py` from evaluation script
- Remove leftover comments in `ARCTester.generate_solution` now that logging is delegated to shell scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic` *(fails: Could not find a version that satisfies the requirement pydantic; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dccc91688322b542e1a270733e1e